### PR TITLE
Archer trap showing up now as well as other bug fixes

### DIFF
--- a/scenes/characters/archer/bear_trap.tscn
+++ b/scenes/characters/archer/bear_trap.tscn
@@ -46,7 +46,7 @@ _data = {
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_byua6"]
 size = Vector2(32, 32)
 
-[node name="Area2D" type="Area2D"]
+[node name="BearTrap" type="Area2D"]
 visibility_layer = 2
 script = ExtResource("1_nfvtx")
 

--- a/scripts/player/archer.gd
+++ b/scripts/player/archer.gd
@@ -11,29 +11,23 @@ var charged_shot_scene = preload("res://scenes/characters/archer/charged_shot.ts
 var trap_scene = preload("res://scenes/characters/archer/bear_trap.tscn")
 @onready var _animation = $AnimationPlayer
 @onready var _sprite = $Sprite2D
-var archer_stats : Dictionary = {"str": 0, "dex": 0, "cons": 0, 
+var stats : Dictionary = {"str": 0, "dex": 0, "cons": 0, 
 	"intel": 0, "wisdom": 0, "charisma": 0,  "health": 10}
 
 func _ready():
 	pass
 
-func _physics_process(delta):
-	input_dir = Input.get_vector("walk_left", "walk_right", "walk_up", "walk_down").normalized()
-	
-	if input_dir.length() != 0:
-		attack_dir = input_dir
-
 func fire_arrow():
 	var arrow_instance = arrow_scene.instantiate()
 	arrow_instance.position = global_position
 	get_tree().current_scene.add_child(arrow_instance)
-	arrow_instance.set_direction(attack_dir)
+	arrow_instance.set_direction(get_parent().attack_dir)
 
 func fire_charged_shot():
 	var charged_shot_instance = charged_shot_scene.instantiate()
 	charged_shot_instance.position = global_position
 	get_tree().current_scene.add_child(charged_shot_instance)
-	charged_shot_instance.set_direction(attack_dir)
+	charged_shot_instance.set_direction(get_parent().attack_dir)
 	
 func place_trap():
 	var trap_instance = trap_scene.instantiate()

--- a/scripts/player/paladin.gd
+++ b/scripts/player/paladin.gd
@@ -10,29 +10,23 @@ var wave_attack_scene = preload("res://scenes/characters/paladin/wave_attack.tsc
 var fire_attack_scene = preload("res://scenes/characters/paladin/fire_arc_attack.tscn")
 @onready var _animation = $AnimationPlayer
 @onready var _sprite = $Sprite2D
-var paladin_stats : Dictionary = {"str": 0, "dex": 0, "cons": 0, 
+var stats : Dictionary = {"str": 0, "dex": 0, "cons": 0, 
 	"intel": 0, "wisdom": 0, "charisma": 0, "health": 15}
 
 func _ready():
 	pass
 
-func _physics_process(delta):
-	input_dir = Input.get_vector("walk_left", "walk_right", "walk_up", "walk_down").normalized()
-	
-	if input_dir.length() != 0:
-		attack_dir = input_dir
-	
 func wave_attack():
 	var wave_attack_instance = wave_attack_scene.instantiate()
 	wave_attack_instance.position = global_position
 	get_tree().current_scene.add_child(wave_attack_instance)
-	wave_attack_instance.set_direction(attack_dir)
+	wave_attack_instance.set_direction(get_parent().attack_dir)
 	
 func fire_attack():
 	var fire_attack_instance = fire_attack_scene.instantiate()
 	fire_attack_instance.position = global_position
 	get_tree().current_scene.add_child(fire_attack_instance)
-	fire_attack_instance.set_direction(attack_dir)
+	fire_attack_instance.set_direction(get_parent().attack_dir)
 
 func _on_hitbox_area_entered(area):
 	if area.is_in_group("hurtbox"):

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -20,7 +20,7 @@ func take_hit(dmg_amount : int):
 	if PlayerVariables.current_hp <= 0:
 		player_class._animation.play("death")
 		dead = true
-		#PlayerVariables.death.emit()
+		PlayerVariables.death.emit()
 		
 
 # Called when the node enters the scene tree for the first time.
@@ -32,27 +32,20 @@ func _ready():
 		add_child(paladin)
 		PlayerVariables.follow_target = paladin
 		
-		PlayerVariables.strength = player_class.paladin_stats["str"]
-		PlayerVariables.dexterity = player_class.paladin_stats["dex"]
-		PlayerVariables.constitution = player_class.paladin_stats["cons"]
-		PlayerVariables.intelligence = player_class.paladin_stats["intel"]
-		PlayerVariables.wisdom = player_class.paladin_stats["wisdom"]
-		PlayerVariables.charisma = player_class.paladin_stats["charisma"]
-		PlayerVariables.current_health_pool = player_class.paladin_stats["health"]
-		
 	elif PlayerVariables.selected_class == "Archer":
 		var archer = archer_scene.instantiate()
 		player_class = archer
 		add_child(archer)
 		PlayerVariables.follow_target = archer
 		
-		PlayerVariables.strength = player_class.archer_stats["str"]
-		PlayerVariables.dexterity = player_class.archer_stats["dex"]
-		PlayerVariables.constitution = player_class.archer_stats["cons"]
-		PlayerVariables.intelligence = player_class.archer_stats["intel"]
-		PlayerVariables.wisdom = player_class.archer_stats["wisdom"]
-		PlayerVariables.charisma = player_class.archer_stats["charisma"]
-		PlayerVariables.current_health_pool = player_class.archer_stats["health"]
+	PlayerVariables.strength = player_class.stats["str"]
+	PlayerVariables.dexterity = player_class.stats["dex"]
+	PlayerVariables.constitution = player_class.stats["cons"]
+	PlayerVariables.intelligence = player_class.stats["intel"]
+	PlayerVariables.wisdom = player_class.stats["wisdom"]
+	PlayerVariables.charisma = player_class.stats["charisma"]
+	PlayerVariables.current_health_pool = player_class.stats["health"]
+	PlayerVariables.current_hp = player_class.stats["health"]
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -81,7 +74,12 @@ func _process(delta):
 		player_class._animation.play("attack2")
 	elif Input.is_action_just_pressed("attack3"):
 		attack = true
-		player_class._animation.play("attack3")
+		# Archer trap placement doesn't have a 3rd attack animation that calls 
+		# the function within the animation so we have to do it manually instead
+		if PlayerVariables.selected_class == "Archer":
+			player_class.place_trap()
+		else:
+			player_class._animation.play("attack3")
 	
 	if input_dir.x < 0:
 		player_class._sprite.scale.x = -1

--- a/scripts/projectiles/arrow.gd
+++ b/scripts/projectiles/arrow.gd
@@ -6,6 +6,8 @@ var speed = 100.0
 var start_position = Vector2.ZERO
 var knockback_coef = 200.0
 
+var enemies_hit : Array
+
 func _ready():
 	start_position = global_position
 	
@@ -26,6 +28,8 @@ func _on_body_entered(body):
 
 func _on_area_entered(area):
 	if area.is_in_group("hurtbox"):
-		var knockback = global_position.direction_to(area.global_position)
-		area.knockback = knockback * knockback_coef
-		area.take_damage()
+		if !enemies_hit.has(area):
+			var knockback = global_position.direction_to(area.global_position)
+			area.knockback = knockback * knockback_coef
+			enemies_hit.append(area)
+			area.take_damage()

--- a/scripts/projectiles/charged_shot.gd
+++ b/scripts/projectiles/charged_shot.gd
@@ -6,6 +6,8 @@ var speed = 400.0
 var start_position = Vector2.ZERO
 var knockback_coef = 300.0
 
+var enemies_hit : Array
+
 func _ready():
 	start_position = global_position
 	
@@ -26,6 +28,8 @@ func _on_body_entered(body):
 
 func _on_area_entered(area):
 	if area.is_in_group("hurtbox"):
-		var knockback = global_position.direction_to(area.global_position)
-		area.knockback = knockback * knockback_coef
-		area.take_damage()
+		if !enemies_hit.has(area):
+			var knockback = global_position.direction_to(area.global_position)
+			area.knockback = knockback * knockback_coef
+			enemies_hit.append(area)
+			area.take_damage()

--- a/scripts/projectiles/wave_attack.gd
+++ b/scripts/projectiles/wave_attack.gd
@@ -6,6 +6,7 @@ var speed = 150.0
 var start_position = Vector2.ZERO
 var knockback_coef = 300.0
 var enemies_hit : Array
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	start_position = global_position
@@ -34,4 +35,4 @@ func _on_area_entered(area):
 			var knockback = global_position.direction_to(area.global_position)
 			area.knockback = knockback * knockback_coef
 			enemies_hit.append(area)
-		area.take_damage()
+			area.take_damage()

--- a/scripts/traps/bear_trap.gd
+++ b/scripts/traps/bear_trap.gd
@@ -21,7 +21,8 @@ func _on_body_entered(body):
 			_animation.play("close")
 			_trap_circle.show()
 			$TrapTimer.start()
-			activated_trap(body)
+			#Commented out as slimes are not an Area2D??
+			#activated_trap(body)
 
 func _on_area_entered(area):
 	if single_use == false:
@@ -32,8 +33,8 @@ func _on_area_entered(area):
 			$TrapTimer.start()
 			activated_trap(area)
 
-func activated_trap(body: Node2D):
-	body.velocity = Vector2(0,0)
+func activated_trap(area: Area2D):
+	pass
 
 
 func _on_timer_timeout():
@@ -42,3 +43,4 @@ func _on_timer_timeout():
 
 func _on_trap_timer_timeout():
 	queue_free()
+	

--- a/scripts/ui/CharacterSelect.gd
+++ b/scripts/ui/CharacterSelect.gd
@@ -3,9 +3,9 @@ extends PanelContainer
 
 func _on_paladin_button_pressed():
 	PlayerVariables.selected_class = "Paladin"
-	get_tree().change_scene_to_file("res://scenes/level/PaladinHellMode.tscn")
+	get_tree().change_scene_to_file("res://scenes/level/ParentPlayerTest.tscn")
 
 
 func _on_ranger_button_pressed():
 	PlayerVariables.selected_class = "Archer"
-	get_tree().change_scene_to_file("res://scenes/level/ArcherTestLevel.tscn")
+	get_tree().change_scene_to_file("res://scenes/level/ParentPlayerTest.tscn")


### PR DESCRIPTION
- Fixed issue where archer's bear trap was not showing up at all.

- Fixed issue where player could change attack direction after attack had started.

- Attached the Parent Player level in the default character select screen so we have full game loop with working parent player script.

- Changed 'paladin_stats' and 'archer_stats,' to just 'stats' to remove duplicate code.

- Uncommented out death screen emit line.

- Updated Archer's attacks with the 'enemy_hit' arrays that were in Paladin attacks.