### PR TITLE
Locking abilities

### DIFF
--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -70,16 +70,22 @@ func _process(delta):
 		attack = true
 		player_class._animation.play("attack1")
 	elif Input.is_action_just_pressed("attack2"):
-		attack = true
-		player_class._animation.play("attack2")
-	elif Input.is_action_just_pressed("attack3"):
-		attack = true
-		# Archer trap placement doesn't have a 3rd attack animation that calls 
-		# the function within the animation so we have to do it manually instead
-		if PlayerVariables.selected_class == "Archer":
-			player_class.place_trap()
+		if PlayerVariables.k_locked:
+			return
 		else:
-			player_class._animation.play("attack3")
+			attack = true
+			player_class._animation.play("attack2")
+	elif Input.is_action_just_pressed("attack3"):
+		if PlayerVariables.l_locked:
+			return
+		else:
+			attack = true
+			# Archer trap placement doesn't have a 3rd attack animation that calls 
+			# the function within the animation so we have to do it manually instead
+			if PlayerVariables.selected_class == "Archer":
+				player_class.place_trap()
+			else:
+				player_class._animation.play("attack3")
 	
 	if input_dir.x < 0:
 		player_class._sprite.scale.x = -1

--- a/scripts/player/player_variables.gd
+++ b/scripts/player/player_variables.gd
@@ -78,16 +78,8 @@ func level_up():
 		k_locked = false
 	
 	if level == 10:
-		k_locked = false
+		l_locked = false
 	
-	# numbers will be for paladin; diff for other classes
-	j_damage = strength/2
-	j_knockback = strength
-	#TODO: implement other ability scaling
-	
-	k_damage = dexterity
-	
-	l_damage = intelligence * 2
 	current_experience = 0
 
 

--- a/scripts/ui/level-up/level_up.gd
+++ b/scripts/ui/level-up/level_up.gd
@@ -78,7 +78,7 @@ func _on_visibility_changed():
 		dice_increase_label.text = dice_format_label % [modifier_symbol, abs(PlayerVariables.con_bonus)]
 		var class_label = "%s - level %s"
 		class_level_label.text = class_label % ["Paladin", PlayerVariables.level+1]
-		if PlayerVariables.level % 4 == 0:
+		if (PlayerVariables.level + 1) % 4 == 0:
 			_initialize_stat_block()
 		else:
 			stat_select_block.visible = false


### PR DESCRIPTION
- PlayerScript now locks K and L abilities to be used only after levels 5 and 10
- Also fixed bug where Stat increase was showing at level 5 instead of level 4 due to running the check before incrementing our "level" value