### PR TITLE
Lots of stuff with levelling and stats

### DIFF
--- a/assets/ui/theme_paper_panel.tres
+++ b/assets/ui/theme_paper_panel.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=15 format=3 uid="uid://ca1ktew34wyrx"]
+[gd_resource type="Theme" load_steps=16 format=3 uid="uid://ca1ktew34wyrx"]
 
 [ext_resource type="StyleBox" uid="uid://dmkku4kq6nt1w" path="res://assets/ui/popup_panel.tres" id="1_dpgob"]
 [ext_resource type="FontFile" uid="uid://bfp3vdqnuro18" path="res://assets/ui/alagard.ttf" id="1_p0a8l"]
@@ -69,6 +69,9 @@ texture_margin_bottom = 8.0
 axis_stretch_horizontal = 1
 axis_stretch_vertical = 1
 region_rect = Rect2(0, 432, 64, 16)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tc1aj"]
+bg_color = Color(0.243137, 0.243137, 0.243137, 0.65098)
 
 [resource]
 default_font = ExtResource("1_p0a8l")
@@ -190,3 +193,11 @@ ProgressBar/font_sizes/font_size = 16
 ProgressBar/fonts/font = ExtResource("1_p0a8l")
 ProgressBar/styles/background = SubResource("StyleBoxTexture_nmcyu")
 ProgressBar/styles/fill = SubResource("StyleBoxTexture_7gykq")
+TooltipLabel/colors/font_color = Color(1, 1, 1, 1)
+TooltipLabel/colors/font_outline_color = Color(0, 0, 0, 0)
+TooltipLabel/colors/font_shadow_color = Color(0, 0, 0, 1)
+TooltipLabel/constants/shadow_offset_x = 0
+TooltipLabel/constants/shadow_offset_y = 0
+TooltipLabel/font_sizes/font_size = 32
+TooltipLabel/fonts/font = ExtResource("1_p0a8l")
+TooltipPanel/styles/panel = SubResource("StyleBoxFlat_tc1aj")

--- a/project.godot
+++ b/project.godot
@@ -41,6 +41,10 @@ version_control/autoload_on_startup=true
 
 enabled=PackedStringArray("res://addons/finite_state_machine/plugin.cfg")
 
+[gui]
+
+timers/tooltip_delay_sec=0.0
+
 [input]
 
 walk_up={

--- a/scenes/basic_items/Pla9CF3.tmp
+++ b/scenes/basic_items/Pla9CF3.tmp
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://d50exvyq23wo"]
+
+[ext_resource type="Script" path="res://scripts/player/player_variables.gd" id="1_jlqa3"]
+
+[node name="PlayerVariables" type="Node"]
+script = ExtResource("1_jlqa3")

--- a/scenes/characters/archer/archer.tscn
+++ b/scenes/characters/archer/archer.tscn
@@ -26,8 +26,8 @@ tracks/0/keys = {
 
 [sub_resource type="Animation" id="Animation_j4jij"]
 resource_name = "attack1"
-length = 0.750008
-step = 0.0833333
+length = 0.428579
+step = 0.0714286
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -35,10 +35,10 @@ tracks/0/path = NodePath("Sprite2D:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.0833333, 0.166667, 0.25, 0.333333, 0.416667, 0.5, 0.583333, 0.666667),
-"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1, 1, 1, 1),
+"times": PackedFloat32Array(0, 0.0714286, 0.142857, 0.214286, 0.285714, 0.357143),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1),
 "update": 1,
-"values": [24, 25, 26, 27, 28, 29, 30, 31, 32]
+"values": [26, 27, 28, 29, 30, 31]
 }
 tracks/1/type = "method"
 tracks/1/imported = false
@@ -47,7 +47,7 @@ tracks/1/path = NodePath(".")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0.4998),
+"times": PackedFloat32Array(0.285714),
 "transitions": PackedFloat32Array(1),
 "values": [{
 "args": [],

--- a/scenes/characters/archer/arrow.tscn
+++ b/scenes/characters/archer/arrow.tscn
@@ -1,22 +1,21 @@
 [gd_scene load_steps=4 format=3 uid="uid://dvpljuj1fmh0e"]
 
 [ext_resource type="Script" path="res://scripts/projectiles/arrow.gd" id="1_drwp7"]
-[ext_resource type="Texture2D" uid="uid://bpbr54bbweyt2" path="res://assets/character/Tiny RPG Character Asset Pack v1.03 -Full 20 Characters/Arrow(Projectile)/Arrow01(32x32).png" id="2_mbge2"]
+[ext_resource type="Texture2D" uid="uid://obvg71envwid" path="res://assets/character/Tiny RPG Character Asset Pack v1.03 -Full 20 Characters/Arrow(Projectile)/Arrow02(100x100).png" id="2_61jdk"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_cdxbq"]
-size = Vector2(3, 5)
+size = Vector2(9, 5)
 
 [node name="Arrow" type="Area2D"]
 script = ExtResource("1_drwp7")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(3.5, 0.5)
+position = Vector2(6.5, 0.5)
 shape = SubResource("RectangleShape2D_cdxbq")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture_filter = 1
-scale = Vector2(0.5, 0.5)
-texture = ExtResource("2_mbge2")
+texture = ExtResource("2_61jdk")
 
 [connection signal="area_entered" from="." to="." method="_on_area_entered"]
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scenes/characters/archer/charged_shot.tscn
+++ b/scenes/characters/archer/charged_shot.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=4 format=3 uid="uid://b6ub5lh25deje"]
+[gd_scene load_steps=5 format=3 uid="uid://b6ub5lh25deje"]
 
 [ext_resource type="Texture2D" uid="uid://vi0hemqlotq" path="res://assets/character/Tiny RPG Character Asset Pack v1.03 -Full 20 Characters/Characters(100x100)/Archer/Archer(Split Effects)/Archer-Attack02_Effect.png" id="1_kgrrt"]
 [ext_resource type="Script" path="res://scripts/projectiles/charged_shot.gd" id="1_xuckw"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vxkq4"]
 size = Vector2(51, 7)
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_i3006"]
+radius = 115.0
 
 [node name="Charged Shot" type="Area2D"]
 script = ExtResource("1_xuckw")
@@ -20,6 +23,12 @@ scale = Vector2(1.00417, 1)
 texture = ExtResource("1_kgrrt")
 hframes = 12
 frame = 10
+
+[node name="DetectionRadius" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DetectionRadius"]
+position = Vector2(115, 0)
+shape = SubResource("CircleShape2D_i3006")
 
 [connection signal="area_entered" from="." to="." method="_on_area_entered"]
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scenes/ui/con_selector.gd
+++ b/scenes/ui/con_selector.gd
@@ -1,0 +1,66 @@
+extends HBoxContainer
+
+@onready var up_button = get_node("btn_up")
+@onready var down_button = get_node("btn_down")
+@onready var label = get_node("Label")
+@onready var parent_panel = $"../../../../../../../../../.."
+@onready var confirm = $"../../../../../../../VBoxContainer/Confirm"
+var label_num = 0
+var min_num = 0
+var max_num = 20
+
+func _ready():
+	parent_panel.out_of_points.connect(_oop)
+	parent_panel.points_free.connect(_un_oop)
+	
+	label_num = min_num
+	label.text = str(label_num)
+
+func _on_btn_down_pressed():
+	if (label_num - 1) < min_num:
+		return
+	else:
+		# adjust actual numbers (skill points & displayed skill #)
+		label_num = label_num-1
+		label.text = str(label_num)
+		PlayerVariables.skill_points = PlayerVariables.skill_points + 1
+		
+		# emit signal to unlock other buttons
+		parent_panel.points_free.emit()
+		
+		#adjust constitution modifier in levelup gui
+		parent_panel.con_update(label_num)
+		
+		# after adjusting, if we're now at the bottom of adjustability, set disabled to true
+		if label_num == min_num:
+			down_button.disabled = true
+
+func _on_btn_up_pressed():
+	if (label_num + 1) > max_num:
+		return
+	else:
+		# if valid up click, update label & remaining skill pts
+		label_num += 1
+		label.text = str(label_num)
+		PlayerVariables.skill_points = PlayerVariables.skill_points - 1
+
+		# if valid up click, then has to be points we can remove
+		down_button.disabled = false
+		
+		# if we're at max level (20 by default) disable upgrading
+		if label_num == max_num:
+			up_button.disabled = true
+			
+		parent_panel.con_update(label_num)
+		
+		# if we are out of skill points, emit signal to lock all buttons
+		if PlayerVariables.skill_points <= 0:
+			parent_panel.out_of_points.emit()
+			
+func _oop():
+	confirm.disabled = false
+	up_button.disabled = true
+	
+func _un_oop():
+	confirm.disabled = true
+	up_button.disabled = false

--- a/scenes/ui/level_up.tscn
+++ b/scenes/ui/level_up.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://ddfbn1ajlagis"]
+[gd_scene load_steps=20 format=3 uid="uid://ddfbn1ajlagis"]
 
 [ext_resource type="Theme" uid="uid://ca1ktew34wyrx" path="res://assets/ui/theme_paper_panel.tres" id="1_jwlph"]
 [ext_resource type="Script" path="res://scripts/ui/level-up/level_up.gd" id="2_2b4as"]
@@ -7,6 +7,7 @@
 [ext_resource type="Script" path="res://scripts/ui/stat_selector.gd" id="3_nrh0t"]
 [ext_resource type="Texture2D" uid="uid://doqjlx5ghppvk" path="res://assets/ui/icon_levelarrow.tres" id="4_jehdm"]
 [ext_resource type="Script" path="res://scripts/ui/level-up/dicebutton.gd" id="5_0deqm"]
+[ext_resource type="Script" path="res://scenes/ui/con_selector.gd" id="6_mub86"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_gr8gi"]
 line_spacing = 1.0
@@ -116,6 +117,7 @@ layout_mode = 2
 
 [node name="label_hp" type="RichTextLabel" parent="Panel/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/hp_select"]
 layout_mode = 2
+tooltip_text = "improve this value by upgrading your constitution!"
 theme_override_colors/default_color = Color(0.454902, 0.247059, 0.223529, 1)
 theme_override_font_sizes/normal_font_size = 48
 bbcode_enabled = true
@@ -170,9 +172,8 @@ theme_override_constants/margin_bottom = 0
 layout_mode = 2
 
 [node name="Label" type="Label" parent="Panel/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/stat_select/MarginContainer/VBoxContainer"]
-visible = false
 layout_mode = 2
-text = "points remaining:"
+text = "hover on ability icons for description"
 
 [node name="statblock" type="GridContainer" parent="Panel/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/stat_select/MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -183,6 +184,7 @@ columns = 3
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
+tooltip_text = "improves physical attack damage!"
 texture = SubResource("AtlasTexture_34src")
 stretch_mode = 2
 
@@ -231,6 +233,7 @@ icon = SubResource("AtlasTexture_0y84b")
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
+tooltip_text = "improves cooldowns and movement speed!"
 texture = SubResource("AtlasTexture_t688h")
 stretch_mode = 2
 
@@ -279,6 +282,7 @@ icon = SubResource("AtlasTexture_0y84b")
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
+tooltip_text = "improves hp gains on levelup!"
 texture = SubResource("AtlasTexture_vlmp3")
 stretch_mode = 2
 
@@ -293,7 +297,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 32
 alignment = 2
-script = ExtResource("3_nrh0t")
+script = ExtResource("6_mub86")
 
 [node name="btn_down" type="Button" parent="Panel/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/stat_select/MarginContainer/VBoxContainer/statblock/con_selector"]
 layout_mode = 2
@@ -327,6 +331,7 @@ icon = SubResource("AtlasTexture_0y84b")
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
+tooltip_text = "improves magic damage!"
 texture = SubResource("AtlasTexture_aynrk")
 stretch_mode = 2
 
@@ -375,6 +380,7 @@ icon = SubResource("AtlasTexture_0y84b")
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
+tooltip_text = "improves the range of AOE abilities!"
 texture = SubResource("AtlasTexture_hq33i")
 stretch_mode = 2
 
@@ -423,6 +429,7 @@ icon = SubResource("AtlasTexture_0y84b")
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 4
+tooltip_text = "increases critical strike (2x damage) chance!"
 texture = SubResource("AtlasTexture_y6jbf")
 stretch_mode = 2
 

--- a/scenes/ui/number_popup.tscn
+++ b/scenes/ui/number_popup.tscn
@@ -3,7 +3,8 @@
 [ext_resource type="Theme" uid="uid://ca1ktew34wyrx" path="res://assets/ui/theme_paper_panel.tres" id="1_y62t1"]
 [ext_resource type="Script" path="res://scripts/ui/number_popup.gd" id="2_8ac31"]
 
-[sub_resource type="LabelSettings" id="LabelSettings_icwn0"]
+[sub_resource type="LabelSettings" id="LabelSettings_my6y0"]
+resource_local_to_scene = true
 font_size = 32
 font_color = Color(1, 0, 0, 1)
 outline_size = 8
@@ -21,6 +22,7 @@ script = ExtResource("2_8ac31")
 label = NodePath("Label")
 damage_color = Color(1, 0, 0, 1)
 heal_color = Color(0.364706, 0.745098, 0, 1)
+crit_color = Color(1, 0.733333, 0, 1)
 metadata/_edit_use_anchors_ = true
 
 [node name="Label" type="Label" parent="."]
@@ -28,4 +30,4 @@ layout_mode = 0
 offset_right = 40.0
 offset_bottom = 23.0
 text = "-8"
-label_settings = SubResource("LabelSettings_icwn0")
+label_settings = SubResource("LabelSettings_my6y0")

--- a/scripts/dragon/boss_chicken.gd
+++ b/scripts/dragon/boss_chicken.gd
@@ -24,11 +24,18 @@ func take_damage(num):
 	if dead:
 		return
 	
-	hitpoints -= num
+	var damage_result = PlayerVariables.crit_roll(num)
+	var damage = damage_result[0]
+	var critted = damage_result[1]
+	
+	hitpoints -= damage
 	
 	var number_ui = damage_number.instantiate()
-	number_ui.numtype = number_ui.NUMTYPE.DAMAGE
-	number_ui.number = num
+	if critted:
+		number_ui.numtype = number_ui.NUMTYPE.CRIT
+	else:
+		number_ui.numtype = number_ui.NUMTYPE.DAMAGE
+	number_ui.number = damage
 	add_child(number_ui)
 	
 	if hitpoints <= 0:

--- a/scripts/player/archer.gd
+++ b/scripts/player/archer.gd
@@ -1,6 +1,5 @@
 extends CharacterBody2D
 
-var speed : float = 50.0
 var attack : bool = false
 var dead : bool = false
 var knockback_coef = 200.0
@@ -12,9 +11,16 @@ var trap_scene = preload("res://scenes/characters/archer/bear_trap.tscn")
 @export var l_texture : Texture
 @onready var _animation = $AnimationPlayer
 @onready var _sprite = $Sprite2D
-var stats : Dictionary = {"str": 0, "dex": 0, "cons": 0, 
-	"intel": 0, "wisdom": 0, "charisma": 0,  "health": 10}
-
+var stats : Dictionary = {
+		"str": 3, 
+		"dex": 5, 
+		"cons": 4, 
+		"intel": 1, 
+		"wisdom": 2, 
+		"charisma": 2,
+		"health": 10
+		}
+var speed : float = 50.0 + (2.5 * stats.dex)
 func _ready():
 	pass
 
@@ -23,8 +29,8 @@ func fire_arrow():
 	arrow_instance.position = global_position
 	
 	# stat scaling
-	var base_damage = 8
-	arrow_instance.damage = base_damage + (PlayerVariables.strength * 0.7) # Bow still scales with Strength but less
+	var base_damage = 3
+	arrow_instance.damage = roundf(base_damage + (PlayerVariables.strength * 0.7)) # Bow still scales with Strength but less
 	
 	get_tree().current_scene.add_child(arrow_instance)
 	arrow_instance.set_direction(get_parent().attack_dir)
@@ -34,9 +40,9 @@ func fire_charged_shot():
 	charged_shot_instance.position = global_position
 	
 	# stat scaling
-	var base_damage = 15
-	charged_shot_instance.pierce_amount = 8 + (PlayerVariables.dexterity * 0.5) # Dexterity increases pierce count
-	charged_shot_instance.damage = base_damage + (PlayerVariables.strength * 0.7) # Bow still scales with Strength but less
+	var base_damage = 2
+	charged_shot_instance.pierce_amount = roundf(3 + (PlayerVariables.dexterity * 0.5)) # Dexterity increases pierce count
+	charged_shot_instance.damage = roundf(base_damage + (PlayerVariables.strength * 0.4)) # Bow still scales with Strength but less
 	PlayerVariables.k_cooldown.wait_time = 1.0 - (PlayerVariables.dexterity * 0.05) # Dex reduces cooldown
 	
 	get_tree().current_scene.add_child(charged_shot_instance)

--- a/scripts/player/paladin.gd
+++ b/scripts/player/paladin.gd
@@ -13,8 +13,15 @@ var fire_attack_scene = preload("res://scenes/characters/paladin/fire_arc_attack
 @export var l_texture : Texture
 @onready var _animation = $AnimationPlayer
 @onready var _sprite = $Sprite2D
-var stats : Dictionary = {"str": 0, "dex": 0, "cons": 0, 
-	"intel": 0, "wisdom": 0, "charisma": 0, "health": 15}
+var stats : Dictionary = {
+		"str": 5, 
+		"dex": 3, 
+		"cons": 4, 
+		"intel": 2, 
+		"wisdom": 1, 
+		"charisma": 2, 
+		"health": 15 
+		}
 
 func _ready():
 	pass
@@ -25,8 +32,8 @@ func wave_attack():
 	wave_attack_instance.position = global_position
 	
 	#stat scaling!:
-	var base_damage = 15
-	wave_attack_instance.damage = base_damage + (PlayerVariables.strength * 1.2) # Slightly lower Strength scaling
+	var base_damage = 5
+	wave_attack_instance.damage = roundf(base_damage + (PlayerVariables.strength * 0.6)) # Slightly lower Strength scaling
 	PlayerVariables.k_cooldown.wait_time = 3.0 - (PlayerVariables.dexterity * 0.05) # Dex reduces cooldown
 	#####
 	
@@ -38,8 +45,8 @@ func fire_attack():
 	fire_attack_instance.position = global_position
 	
 	# stat scaling!:
-	var base_damage = 20
-	fire_attack_instance.damage = base_damage + (PlayerVariables.strength * 0.8) + (PlayerVariables.intelligence * 0.5) # Intelligence adds fire scaling
+	var base_damage = 10
+	fire_attack_instance.damage = roundf(base_damage + (PlayerVariables.strength * 0.8) + (PlayerVariables.intelligence * 1.0)) # Intelligence adds fire scaling
 	PlayerVariables.l_cooldown.wait_time = 10.0 - (PlayerVariables.dexterity * 0.05) # Dex reduces cooldown
 	
 	get_tree().current_scene.add_child(fire_attack_instance)
@@ -52,8 +59,8 @@ func _on_hitbox_area_entered(area):
 		area.knockback = knockback * knockback_coef
 		
 		#damage on sword swing
-		var base_damage = 10
-		var damage = base_damage + (PlayerVariables.strength * 1.5) # Sword swing scales with Strength
+		var base_damage = 5
+		var damage = roundf(base_damage + (PlayerVariables.strength * 0.8)) # Sword swing scales with Strength
 		area.take_damage(damage)
 		
 func _start_cooldown(attack_name : String):

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -111,6 +111,8 @@ func _physics_process(delta):
 	if input_dir.length() != 0:
 		attack_dir = input_dir
 	
+	# just putting it in process, cause i can't be bothered right now
+	speed = 50.0 + (1.5 * PlayerVariables.dexterity)
 	player_class.velocity = input_dir * speed
 	player_class.move_and_slide()
 	

--- a/scripts/player/player_variables.gd
+++ b/scripts/player/player_variables.gd
@@ -15,8 +15,8 @@ var current_hp : int = current_health_pool
 @export var wisdom : int = 10
 @export var charisma : int = 14
 @export var hit_die : Die
-@export var current_experience : int = 23
-@export var experience_to_level : int = 25
+@export var current_experience : int = 0
+@export var experience_to_level : int = 5
 
 #@export_category("Ability 1 Stats")
 #@export var j_damage : float # paladin: str
@@ -115,6 +115,8 @@ func level_up():
 		unlock_l.emit()
 	
 	current_experience = 0
+	experience_to_level = experience_to_level + 5
+	follow_target.speed = 50.0 + (2.5 * dexterity)
 	
 func cooldown_ability(ability_name):
 	match ability_name:
@@ -140,6 +142,19 @@ func _on_cd_end(ability_name):
 		'l':
 			l_on_cd = false
 
+func crit_roll(damage):
+	cha_bonus = floori((charisma-10.0)/2.0)
+	var d20 = Die.new(20)
+	var critted : bool = false
+	var roll = d20.roll() 
+	var mod_roll = roll + cha_bonus
+	print(mod_roll)
+	if roll == 20 or mod_roll > 20:
+		damage = damage * 2
+		critted = true
+		
+	print("damage: " + str(damage))
+	return [damage, critted]
 
 
 

--- a/scripts/projectiles/arrow.gd
+++ b/scripts/projectiles/arrow.gd
@@ -26,11 +26,13 @@ func _on_body_entered(body):
 		var knockback = global_position.direction_to(body.global_position)
 		body.knockback = knockback * knockback_coef
 		body.take_damage(damage)
+		queue_free()
 
 func _on_area_entered(area):
-	if area.is_in_group("hurtbox"):
+	if area.is_in_group("hurtbox") && !area.parent.dead:
 		if !enemies_hit.has(area):
 			var knockback = global_position.direction_to(area.global_position)
 			area.knockback = knockback * knockback_coef
 			enemies_hit.append(area)
 			area.take_damage(damage)
+		queue_free()

--- a/scripts/projectiles/charged_shot.gd
+++ b/scripts/projectiles/charged_shot.gd
@@ -28,13 +28,30 @@ func _process(delta: float):
 		#body.take_damage(damage)
 
 func _on_area_entered(area):
-	if area.is_in_group("hurtbox"):
+	if area.is_in_group("hurtbox") and !area.parent.dead:
 		if !enemies_hit.has(area):
 			var knockback = global_position.direction_to(area.global_position)
 			area.knockback = knockback * knockback_coef
 			enemies_hit.append(area)
 			pierce_amount -= 1
 			area.take_damage(damage)
+			_heatseek(area)
 		if pierce_amount <= 0:
 			queue_free()
+
+func _heatseek(area):
+	var close_enemies = $DetectionRadius.get_overlapping_areas()
+	var closest_enemy
+	var closest_distance = $DetectionRadius.get_node("CollisionShape2D").shape.radius
+	for enemy in close_enemies:
+		if enemy == area:
+			continue
+		if enemy.is_in_group("hurtbox") and !enemy.parent.dead:
+			var enemy_distance = global_position.distance_to(enemy.global_position)
+			if enemy_distance < closest_distance:
+				closest_distance = enemy_distance
+				closest_enemy = enemy
 		
+	if closest_enemy != null:
+		set_direction(global_position.direction_to(closest_enemy.global_position))
+	

--- a/scripts/skeleton/dead.gd
+++ b/scripts/skeleton/dead.gd
@@ -2,3 +2,13 @@ extends StateMachineState
 
 func on_enter():
 	state_machine.animation_player.play("die")
+	
+	var deathtimer = Timer.new()
+	add_child(deathtimer)
+	deathtimer.timeout.connect(_on_death_timeout)
+	deathtimer.wait_time = 30.0
+	deathtimer.one_shot = true
+	deathtimer.start()
+	
+func _on_death_timeout():
+	state_machine.get_parent().queue_free()

--- a/scripts/skeleton/skeleton.gd
+++ b/scripts/skeleton/skeleton.gd
@@ -5,7 +5,7 @@ extends CharacterBody2D
 @onready var _sprite = $Sprite2D
 
 @export var follow_target : CharacterBody2D
-@export var hitpoints = 5
+@export var hitpoints = 15
 
 @export var movement_speed : float = 30.0
 @export var dead = false
@@ -21,14 +21,18 @@ func take_damage(num):
 	if dead:
 		return
 	
-	#TODO: remove; only for testing damage purposes
-	num = 1
+	var damage_result = PlayerVariables.crit_roll(num)
+	var damage = damage_result[0]
+	var critted = damage_result[1]
 	
-	hitpoints -= num
+	hitpoints -= damage
 	
 	var number_ui = damage_number.instantiate()
-	number_ui.numtype = number_ui.NUMTYPE.DAMAGE
-	number_ui.number = num
+	if critted:
+		number_ui.numtype = number_ui.NUMTYPE.CRIT
+	else:
+		number_ui.numtype = number_ui.NUMTYPE.DAMAGE
+	number_ui.number = damage
 	add_child(number_ui)
 	
 	if hitpoints <= 0:

--- a/scripts/slime/dead.gd
+++ b/scripts/slime/dead.gd
@@ -2,6 +2,13 @@ extends StateMachineState
 
 func on_enter():
 	state_machine.animation_player.play("die")
+	
+	var deathtimer = Timer.new()
+	add_child(deathtimer)
+	deathtimer.timeout.connect(_on_death_timeout)
+	deathtimer.wait_time = 30.0
+	deathtimer.one_shot = true
+	deathtimer.start()
 
 func on_animation_finished(_anim_name: StringName) -> void:
 	if _anim_name == "die":
@@ -12,3 +19,6 @@ func on_animation_finished(_anim_name: StringName) -> void:
 
 func _on_timer_timeout():
 	state_machine.parent.instance_child_slimes()
+	
+func _on_death_timeout():
+	state_machine.parent.queue_free()

--- a/scripts/slime/slime.gd
+++ b/scripts/slime/slime.gd
@@ -5,7 +5,7 @@ extends CharacterBody2D
 @onready var _sprite = $Sprite2D
 
 @export var follow_target : CharacterBody2D
-@export var hitpoints = 4
+@export var hitpoints = 25
 @export var level = 2
 
 @export var movement_speed : float = 15.0
@@ -23,20 +23,24 @@ var damage_number = preload("res://scenes/ui/number_popup.tscn")
 func _ready():
 	scale.x = (0.5*level) + 0.25
 	scale.y = (0.5*level) + 0.25
-	hitpoints = (0.5*level)*4 + 1
+	hitpoints = 10 * level
 
 func take_damage(num):
 	if dead:
 		return
 	
-	#TODO: remove; only for testing damage purposes
-	num = 1
+	var damage_result = PlayerVariables.crit_roll(num)
+	var damage = damage_result[0]
+	var critted = damage_result[1]
 	
-	hitpoints -= num
+	hitpoints -= damage
 	
 	var number_ui = damage_number.instantiate()
-	number_ui.numtype = number_ui.NUMTYPE.DAMAGE
-	number_ui.number = num
+	if critted:
+		number_ui.numtype = number_ui.NUMTYPE.CRIT
+	else:
+		number_ui.numtype = number_ui.NUMTYPE.DAMAGE
+	number_ui.number = damage
 	add_child(number_ui)
 	
 	if hitpoints <= 0:

--- a/scripts/ui/number_popup.gd
+++ b/scripts/ui/number_popup.gd
@@ -1,12 +1,12 @@
 extends Control
 
-enum NUMTYPE {DAMAGE, HEAL}
+enum NUMTYPE {DAMAGE, HEAL, CRIT}
 @export var numtype : NUMTYPE
 
 @export var label : Label
 @export var damage_color : Color
 @export var heal_color : Color
-
+@export var crit_color : Color
 var number
 
 func _ready():
@@ -22,6 +22,11 @@ func _ready():
 			label.label_settings.outline_color = Color.BLACK
 			label.text = "+" + str(number)
 			timelength = 3
+		NUMTYPE.CRIT:
+			label.label_settings.font_color = crit_color
+			label.label_settings.outline_color = Color.BLACK
+			label.text = "-" + str(number) + "!"
+			timelength = 1.5
 			
 	var tween = create_tween().set_parallel(true)
 	tween.tween_property(label, "position", Vector2(0, -20), timelength)


### PR DESCRIPTION
- Paladin and Ranger now have respective default stats
- Stats in level up menu now show tooltip on their hover
- Shortened Archer's attack animation (made it faster)
- Changed arrow sprite to one that looked cooler
- Changed arrow to be bigger to match with aesthetic
- + Added Charge-shot BOUNCING
- Changing constitution in the level up menu now shows updated hp bonus in the health "fixed or dice roll" selector
- Player now does a stat increase every 2 levels instead of every 4
- Slime, skeleton, dragon now have updated HP values that contribute to their respective difficulties
- Number popup for levelup no longer changes colors when you do damage to an enemy afterwards
- Fixed issue where "Paladin" showed in the level up menu of Ranger
- Added critical hits that scale off of Charisma\
- Bodies despawn after 30 seconds